### PR TITLE
Pass parameters through FB app_data object

### DIFF
--- a/lib/carrot-facebook/middleware.rb
+++ b/lib/carrot-facebook/middleware.rb
@@ -21,6 +21,7 @@ module Carrot
               begin
                 path_override                  = Yajl::Parser.parse(env[:facebook_data][:app_data], symbolize_keys: true) 
                 env['PATH_INFO']               = path_override[:path] if path_override[:path]
+                env['QUERY_STRING']            = path_override[:params].map { |params| params.join('=') }.join('&') if path_override[:params]
                 env[:facebook_data][:app_data] = path_override
               rescue => e
                 env[:facebook_data][:app_data] = env[:facebook_data][:app_data]

--- a/spec/middleware_spec.rb
+++ b/spec/middleware_spec.rb
@@ -153,4 +153,16 @@ describe Carrot::Facebook::Middleware do
       expect(@request[:facebook_data]).to eq @valid_facebook_data.merge({ issued_at: 1331669185, app_data: { path: '/page/terms' } })
     end
   end
+
+  context "when sending parameters in the request" do
+    before(:all) do
+      @signed_request = 'signed_request=PGQuysjAoFJBxu2Me_HizoVv8BdiPdm5wBhkcdHZaR0.eyJhbGdvcml0aG0iOiJITUFDLVNIQTI1NiIsImFwcF9kYXRhIjoie1wicGF0aFwiOlwiXC9wYWdlXC90ZXJtc1wifSIsImlzc3VlZF9hdCI6MTMzMTY2OTE4NSwicGFnZSI6eyJpZCI6IjEzNzczOTk4Mjk0MjI3NCIsImxpa2VkIjpmYWxzZSwiYWRtaW4iOnRydWV9LCJ1c2VyIjp7ImNvdW50cnkiOiJ1cyIsImxvY2FsZSI6ImVuX1VTIiwiYWdlIjp7Im1pbiI6MjF9fX0'
+      @request        = Rack::MockRequest.env_for('/', lint: true, fatal: true,  method: 'POST', input: @signed_request)
+      @response       = Carrot::Facebook::Middleware.new(@app).call(@request)
+    end
+
+    it 'should properly set parameters passed to :facebook_data' do
+      pending
+    end
+  end
 end


### PR DESCRIPTION
I found myself needing to pass parameters through `fb_dispatch` and there was no way to do this with the current version of carrotbook.  Since it looks like carrotbook is getting deprecated, I figure I'd throw this here, in case it's useful. (Since there is no `renderer.rb` it may not be applicable, you can make the call)

an example of how this middleware extension works:

`render fb_dispatch: "?sk=app_#{Carrotbook.configuration.fb_app_id}&app_data={\"path\":\"#{finalists_path}\",\"params\":{\"show_card\":\"3\",\"foo\":\"bar\"}}"`

By adding the **params** object within the `app_data` object, we can now set Rack's `env['QUERY_STRING']` and pass parameters around within facebook.
